### PR TITLE
extension production build works now. Also fixes node_env issues in prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "client": "yarn workspace frontend serve",
     "server": "yarn workspace backend dev",
     "extension": "yarn workspace extension start",
-    "zip-server": "cd packages/backend && zip -q -r micdrop-build.zip build dist package.json yarn.lock && mv micdrop-build.zip ../..",
-    "zip-ext": "cd packages/extension/dist && zip -q -r micdrop-ext-build.zip * && mv micdrop-ext-build.zip ../../.."
+    "zip-server": "yarn build && cd packages/backend && zip -q -r micdrop-build.zip build dist package.json yarn.lock && mv micdrop-build.zip ../..",
+    "zip-ext": "yarn build && cd packages/extension/dist && zip -q -r micdrop-ext-build.zip * && mv micdrop-ext-build.zip ../../.."
   },
   "dependencies": {
     "concurrently": "^5.3.0"

--- a/packages/extension/vue.config.js
+++ b/packages/extension/vue.config.js
@@ -24,5 +24,6 @@ module.exports = {
         ],
       },
     },
+    extract: false,
   },
 };


### PR DESCRIPTION
Closes #15 

building the extension for production was not working properly. It was extracting the CSS which made it behave incorrectly.

The only reason it worked previously is because the dev `dist` folder was being used accidentally. However, that was set with `NODE_ENV` as `development`. 

I updated the build so that it doesn't extract CSS. That way it can build with `NODE_ENV` as `production` and still work. Also updated `zip` scripts so that they build first to make sure this doesn't happen again.